### PR TITLE
Add @automattic prefix to package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ import 'isolated-block-editor/build-browser/core.css';
 
 The module is currently only available on Github and can be added with:
 
-`npm install "github:automattic/isolated-block-editor#1.2.0" --save` (where `1.2.0` is the version you want to use)
+`npm install @automattic/isolated-block-editor@1.2.0" --save` (where `1.2.0` is the version you want to use)
 
 ## Future
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "isolated-block-editor",
+	"name": "@automattic/isolated-block-editor",
 	"version": "1.3.0",
 	"description": "Repackages Gutenberg's editor playground as multi-instance editor.",
 	"main": "build/index.js",


### PR DESCRIPTION
Add `@automattic` prefix to the package name.

This should avoid clashes with https://www.npmjs.com/package/isolated-block-editor