### PR TITLE
Expand click-outside exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix handling of initial content from `onLoad` when collaborative editing is enabled
 - Improved reliability of collaborative editing when multiple peers are typing simultaneously
+- Fix blur event when clicking in some UI components in the block inspector
 
 ## [2.3.0] - 2021-07-29
 

--- a/src/components/block-editor-container/click-outside.js
+++ b/src/components/block-editor-container/click-outside.js
@@ -11,11 +11,27 @@ const ClickOutsideWrapper = withFocusOutside(
 			this.props.onFocus();
 		}
 
+		// Clicks in the media modal or popup components are considered in the editor
+		isInspectorElement( element ) {
+			if ( element.closest( '.components-color-picker' ) ) {
+				return true;
+			}
+
+			if ( element.closest( '.block-editor-block-inspector' ) ) {
+				return true;
+			}
+
+			if ( element.classList.contains( 'media-modal' ) ) {
+				return true;
+			}
+
+			return false;
+		}
+
 		handleFocusOutside( ev ) {
 			const target = ev.relatedTarget || ev.target;
 
-			// Ignore clicks in the media modal - consider it inside the editor
-			if ( target && target.classList.contains( 'media-modal' ) ) {
+			if ( target && this.isInspectorElement( target ) ) {
 				return;
 			}
 


### PR DESCRIPTION
Chase Gutenberg's ever-changing elements.

This fixes the situation where you open the block inspector and then click in an element that might have a popover or a colour picker (which may exist in a portal). This was triggering a blur event in the editor, causing the inspector to close.