### PR TITLE
Purge tsconfig.tsbuildinfo in yarn clean

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"build:browser": "BUILD_ENV=es6 NODE_ENV=production webpack --mode production --progress --config ./webpack.config.browser.js && rm build-browser/core.js",
 		"build:types": "tsc --build",
 		"build": "yarn build:es6 && yarn build:cjs && yarn build:browser && yarn build:types",
-		"clean": "rm -rf build build-module build-browser build-types dist",
+		"clean": "rm -rf build build-module build-browser build-types dist tsconfig.tsbuildinfo",
 		"dist": "yarn build && rm -rf dist && mkdir dist && zip build-browser.zip -r build-browser && mv build-browser.zip dist/isolated-block-editor.zip && release-it",
 		"storybook": "start-storybook -p 6006"
 	},


### PR DESCRIPTION
See https://github.com/microsoft/TypeScript/issues/40173

Because of incremental compilation, we cannot guarantee a consistent TS build unless we delete the `tsconfig.tsbuildinfo` file before each clean build. This is especially true if we rimraf the `build-types` folder before building. Try removing the `build-types` folder and run `yarn build:types`, and it's likely that you won't get a complete build, depending on when you last built it.