### PR TITLE
Fix blur clicks when they go to the root popover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.1] - 2021-09-09
+
+### Fixed
+
+- Further fix to blur event in block inspector to catch clicks that fall in the popover itself
+
 ## [2.4.0] - 2021-09-08
 
 ### Breaking changes

--- a/src/components/block-editor-container/click-outside.js
+++ b/src/components/block-editor-container/click-outside.js
@@ -13,14 +13,17 @@ const ClickOutsideWrapper = withFocusOutside(
 
 		// Clicks in the media modal or popup components are considered in the editor
 		isInspectorElement( element ) {
+			// Inside a colour picker popover
 			if ( element.closest( '.components-color-picker' ) ) {
 				return true;
 			}
 
-			if ( element.closest( '.block-editor-block-inspector' ) ) {
+			// Inside the inspector
+			if ( element.closest( '.block-editor-block-inspector' ) || element.closest( '.iso-inspector' ) ) {
 				return true;
 			}
 
+			// In the media modal
 			if ( element.classList.contains( 'media-modal' ) ) {
 				return true;
 			}


### PR DESCRIPTION
If you sometimes clicked on a text label in the inspector it would close the inspector