### PR TITLE
Collab: Infer relative caret positions

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
 		"build": "yarn build:es6 && yarn build:cjs && yarn build:browser && yarn build:types",
 		"clean": "rm -rf build build-module build-browser build-types dist tsconfig.tsbuildinfo",
 		"dist": "yarn build && rm -rf dist && mkdir dist && zip build-browser.zip -r build-browser && mv build-browser.zip dist/isolated-block-editor.zip && release-it",
-		"storybook": "start-storybook -p 6006"
+		"storybook": "start-storybook -p 6006",
+		"test": "wp-scripts test-unit-js"
 	},
 	"sideEffects": [
 		"*.css",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
 		"@wordpress/wordcount": "^3.2.1",
 		"classnames": "^2.3.1",
 		"debug": "^4.3.2",
+		"diff": "^4.0.2",
 		"react": "17.0.2",
 		"react-autosize-textarea": "^7.1.0",
 		"react-dom": "17.0.2",

--- a/src/components/collaborative-editing/use-yjs/algorithms/__tests__/relative-position.js
+++ b/src/components/collaborative-editing/use-yjs/algorithms/__tests__/relative-position.js
@@ -1,0 +1,48 @@
+import { calculateNewPosition } from '../relative-position';
+
+describe( 'calculateNewPosition', () => {
+	it( 'should map "|foo" to "|bar"', () => {
+		const newPosition = calculateNewPosition( 'foo', 'bar', 0 );
+		expect( newPosition ).toBe( 0 );
+	} );
+
+	it( 'should map "foo|" to "bar|"', () => {
+		const newPosition = calculateNewPosition( 'foo', 'bar', 3 );
+		expect( newPosition ).toBe( 3 );
+	} );
+
+	it( 'should map "abc|" to "bc|"', () => {
+		const newPosition = calculateNewPosition( 'abc', 'bc', 3 );
+		expect( newPosition ).toBe( 2 );
+	} );
+
+	it( 'should map "foo|baz" to "bar|baz"', () => {
+		const newPosition = calculateNewPosition( 'foobaz', 'barbaz', 3 );
+		expect( newPosition ).toBe( 3 );
+	} );
+
+	it( 'should map "fob|ar" to "foob|ar"', () => {
+		const newPosition = calculateNewPosition( 'fobar', 'foobar', 3 );
+		expect( newPosition ).toBe( 4 );
+	} );
+
+	it( 'should map "foo|" to "foo|bar"', () => {
+		const newPosition = calculateNewPosition( 'foo', 'foobar', 3 );
+		expect( newPosition ).toBe( 3 );
+	} );
+
+	it( 'should map "bar|" to "foobar|"', () => {
+		const newPosition = calculateNewPosition( 'bar', 'foobar', 3 );
+		expect( newPosition ).toBe( 6 );
+	} );
+
+	it( 'should ignore HTML tags', () => {
+		const newPosition = calculateNewPosition( '<em>foo</em>', '<strong>foo</strong>', 3 );
+		expect( newPosition ).toBe( 3 );
+	} );
+
+	it( 'should map "<li>bar|</li>" to "<li>foobar|</li>"', () => {
+		const newPosition = calculateNewPosition( '<li>bar</li>', '<li>foobar</li>', 3 );
+		expect( newPosition ).toBe( 6 );
+	} );
+} );

--- a/src/components/collaborative-editing/use-yjs/algorithms/relative-position.js
+++ b/src/components/collaborative-editing/use-yjs/algorithms/relative-position.js
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import { diffChars } from 'diff';
+
+/**
+ * Determine the position my caret should be at, after a peer modifies
+ * the content in which my caret is contatined.
+ *
+ * To match the position notation in Gutenberg, HTML tags are ignored.
+ * See unit tests for examples of what should happen.
+ *
+ * @param {string} oldText
+ * @param {string} newText
+ * @param {number} position Index-based position of the caret in oldText
+ */
+export function calculateNewPosition( oldText, newText, position ) {
+	let cur = 0;
+	let offset = 0;
+	const changes = diffChars( stripHTML( oldText ), stripHTML( newText ) );
+
+	for ( const { count, added, removed } of changes ) {
+		if ( ! added && ! removed ) {
+			cur += count;
+		}
+		if ( cur >= position ) {
+			break;
+		}
+
+		if ( added ) {
+			offset += count;
+		}
+		if ( removed ) {
+			offset -= count;
+		}
+	}
+
+	return offset + position;
+}
+
+/**
+ * @param {string} html
+ */
+function stripHTML( html ) {
+	const document = new window.DOMParser().parseFromString( html, 'text/html' );
+	return document.body.textContent || '';
+}

--- a/src/components/collaborative-editing/use-yjs/index.js
+++ b/src/components/collaborative-editing/use-yjs/index.js
@@ -162,7 +162,7 @@ export default function useYjs( { settings } ) {
 			selectionStart: select( 'core/block-editor' ).getSelectionStart(),
 			selectionEnd: select( 'core/block-editor' ).getSelectionEnd(),
 		};
-	}, [] );
+	} );
 
 	const { setAvailablePeers, setPeerSelection, updateBlocksWithUndo } = useDispatch( 'isolated/editor' );
 	const { selectionChange } = useDispatch( 'core/block-editor' );


### PR DESCRIPTION
⏸ Pivoting to #71 which will allow `Y.RelativePosition`. Will probably close this PR.

Closes #39

We should wait until `batch()` is widely available in `@wordpress/data`. (It was [recently released](https://github.com/WordPress/gutenberg/blob/7310097da5e16159b79e6e039a2cb3812cb9055e/packages/data/CHANGELOG.md#610-2021-09-09) in 6.1.0, slated to ship in Gutenberg 11.6)

🚧 🚧 🚧