### PR TITLE
Storybook: Add a reset button for Collab story peers

### DIFF
--- a/stories/collab/mock-transport.js
+++ b/stories/collab/mock-transport.js
@@ -64,4 +64,20 @@ const mockTransport = ( channelId ) => ( {
 	},
 } );
 
+export const resetPeers = ( channelId ) => {
+	window.localStorage.setItem( `isoEditorYjsPeers-${ channelId }`, '' );
+};
+
+export const setUpForceRemount = ( forceRemount, channelId ) => {
+	listeners.push( {
+		event: 'storage',
+		listener: window.addEventListener( 'storage', ( event ) => {
+			if ( event.storageArea !== localStorage ) return;
+			if ( event.key === `isoEditorYjsPeers-${ channelId }` && ! event.newValue ) {
+				forceRemount();
+			}
+		} ),
+	} );
+};
+
 export default mockTransport;


### PR DESCRIPTION
Adds a "Reset peers" button to the collaboration mode stories.

This is only a DX enhancement to combat a inconsistency problem when hot module reloading. Does not affect production builds.