### PR TITLE
Make eslint and prettier work again

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,6 +30,8 @@ module.exports = {
 	},
 	ignorePatterns: [ 'build/', 'build-*/', 'node_modules/', '*.d.ts' ],
 	rules: {
+		'jsdoc/check-line-alignment': 'off',
+		'jsdoc/require-property-description': 'off',
 		'@wordpress/dependency-group': 'error',
 		'@wordpress/react-no-unsafe-timeout': 'error',
 		'no-restricted-syntax': [
@@ -140,4 +142,9 @@ module.exports = {
 			],
 		},
 	],
+	settings: {
+		jsdoc: {
+			mode: 'typescript',
+		},
+	},
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,6 +28,7 @@ module.exports = {
 	globals: {
 		wp: 'off',
 	},
+	ignorePatterns: [ 'build/', 'build-*/', 'node_modules/', '*.d.ts' ],
 	rules: {
 		'@wordpress/dependency-group': 'error',
 		'@wordpress/react-no-unsafe-timeout': 'error',

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+build/
+build-*/
+*.d.ts

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"build": "yarn build:es6 && yarn build:cjs && yarn build:browser && yarn build:types",
 		"clean": "rm -rf build build-module build-browser build-types dist tsconfig.tsbuildinfo",
 		"dist": "yarn build && rm -rf dist && mkdir dist && zip build-browser.zip -r build-browser && mv build-browser.zip dist/isolated-block-editor.zip && release-it",
+		"format": "wp-scripts format",
 		"lint:js": "wp-scripts lint-js",
 		"storybook": "start-storybook -p 6006"
 	},

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"build": "yarn build:es6 && yarn build:cjs && yarn build:browser && yarn build:types",
 		"clean": "rm -rf build build-module build-browser build-types dist tsconfig.tsbuildinfo",
 		"dist": "yarn build && rm -rf dist && mkdir dist && zip build-browser.zip -r build-browser && mv build-browser.zip dist/isolated-block-editor.zip && release-it",
+		"lint:js": "wp-scripts lint-js",
 		"storybook": "start-storybook -p 6006"
 	},
 	"sideEffects": [
@@ -85,6 +86,7 @@
 		"@wordpress/wordcount": "^3.2.1",
 		"classnames": "^2.3.1",
 		"debug": "^4.3.2",
+		"eslint-plugin-eslint-comments": "^3.2.0",
 		"react": "17.0.2",
 		"react-autosize-textarea": "^7.1.0",
 		"react-dom": "17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7645,6 +7645,14 @@ eslint-module-utils@^2.6.2:
     debug "^3.2.7"
     pkg-dir "^2.0.0"
 
+eslint-plugin-eslint-comments@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.2.0.tgz#9e1cd7b4413526abb313933071d7aba05ca12ffa"
+  integrity sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==
+  dependencies:
+    escape-string-regexp "^1.0.5"
+    ignore "^5.0.5"
+
 eslint-plugin-import@^2.23.4, eslint-plugin-import@^2.24.2:
   version "2.24.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.24.2.tgz#2c8cd2e341f3885918ee27d18479910ade7bb4da"
@@ -9557,7 +9565,7 @@ ignore@^4.0.3, ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.1.4, ignore@^5.1.8, ignore@~5.1.8:
+ignore@^5.0.5, ignore@^5.1.4, ignore@^5.1.8, ignore@~5.1.8:
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==


### PR DESCRIPTION
## Proposed changes

- Install the missing `eslint-plugin-eslint-comments` plugin to make eslint run again.
- Add ignore patterns to eslintrc.
- Add ignore patterns to prettierignore.
- Add yarn commands for eslint and prettier (following [wp-scripts conventions](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-scripts/#setup)).

## To test

`yarn lint:js --fix && yarn format` should fix a bunch of issues, but only in directories we want.