### PR TITLE
Storybook: Add stories for IsolatedBlockEditor

### DIFF
--- a/stories/IsolatedBlockEditor.stories.tsx
+++ b/stories/IsolatedBlockEditor.stories.tsx
@@ -1,0 +1,52 @@
+/**
+ * Internal dependencies
+ */
+import IsolatedBlockEditor, { DocumentSection } from '../src/index';
+
+export default {
+	title: 'Isolated Block Editor',
+	component: IsolatedBlockEditor,
+};
+
+export const Default = () => {
+	return <IsolatedBlockEditor settings={ {} } />;
+};
+
+export const ToolbarSettings = ( toolbarSettings ) => {
+	return (
+		<IsolatedBlockEditor settings={ { iso: { toolbar: toolbarSettings } } }>
+			<DocumentSection>Arbitrary content can go here.</DocumentSection>
+		</IsolatedBlockEditor>
+	);
+};
+ToolbarSettings.args = {
+	inserter: true,
+	inspector: true,
+	navigation: true,
+	toc: true,
+	documentInspector: 'Document',
+};
+
+export const MoreMenu = ( moreMenuSettings ) => {
+	return <IsolatedBlockEditor settings={ { iso: { moreMenu: moreMenuSettings, toolbar: { inspector: true } } } } />;
+};
+MoreMenu.args = {
+	editor: true,
+	fullscreen: true,
+	preview: true,
+	topToolbar: true,
+};
+
+export const MultipleEditors = ( { count } ) => {
+	const arr = Array( count ).fill( null );
+	return (
+		<>
+			{ arr.map( ( _, idx ) => (
+				<div style={ { marginBottom: 16 } } key={ idx }>
+					<IsolatedBlockEditor settings={ {} } />
+				</div>
+			) ) }
+		</>
+	);
+};
+MultipleEditors.args = { count: 2 };


### PR DESCRIPTION
Adds some stories of the basic `<IsolatedBlockEditor>` for easier exploration of settings, testing of behaviors, and comparison with the collab-ready instances.

cc @johngodley in case you want to dev/test with it too.

## To test

Note that standalone builds are currently broken and blocked due to https://github.com/WordPress/gutenberg/issues/35282. To build, you'll need a local copy of the latest Gutenberg repo and replace the `@wordpress/keyboard-shortcuts` package with it.

```diff
// package.json

-  "@wordpress/keyboard-shortcuts": "^3.0.2",
+  "@wordpress/keyboard-shortcuts": "file:../gutenberg/packages/keyboard-shortcuts",
```

Then run `yarn storybook`.