### PR TITLE
Collab: focus peer selected block on avatar click

### DIFF
--- a/src/components/collaborative-editing/components/avatars/Avatars.stories.tsx
+++ b/src/components/collaborative-editing/components/avatars/Avatars.stories.tsx
@@ -28,12 +28,16 @@ const generateRandomPeers = ( count ) => {
 		: [];
 };
 
+const onAvatarClickMock = () => {};
+
 type Props = {
 	peerCount: number;
 };
 
 const Template: Story< Props > = ( { peerCount } ) => {
-	return <CollaborativeEditingAvatars peers={ generateRandomPeers( peerCount ) } />;
+	return (
+		<CollaborativeEditingAvatars peers={ generateRandomPeers( peerCount ) } onAvatarClick={ onAvatarClickMock } />
+	);
 };
 
 export const Default = Template.bind( {} );
@@ -47,7 +51,7 @@ Empty.args = {
 };
 
 export const NoImage = ( args ) => {
-	return <CollaborativeEditingAvatar peer={ args } />;
+	return <CollaborativeEditingAvatar peer={ args } onAvatarClick={ onAvatarClickMock } />;
 };
 NoImage.args = {
 	id: 0,

--- a/src/components/collaborative-editing/components/avatars/index.js
+++ b/src/components/collaborative-editing/components/avatars/index.js
@@ -39,14 +39,11 @@ export function CollaborativeEditingAvatar( { peer, onAvatarClick } ) {
 	const [ isVisible, setIsVisible ] = useState( false );
 
 	return (
-		<div
-			className="iso-editor-collab-avatars__avatar"
+		<button
+			className="iso-editor-collab-avatars__avatar-btn"
 			aria-label={ peer.name }
 			onMouseEnter={ () => setIsVisible( true ) }
 			onMouseLeave={ () => setIsVisible( false ) }
-			tabIndex={ -1 }
-			role="button"
-			onKeyDown={ () => {} }
 			onClick={ () => onAvatarClick( peer ) }
 			style={ {
 				borderColor: peer.color,
@@ -63,7 +60,7 @@ export function CollaborativeEditingAvatar( { peer, onAvatarClick } ) {
 			) : (
 				<span className="iso-editor-collab-avatars__name-initial">{ peer.name.charAt( 0 ) }</span>
 			) }
-		</div>
+		</button>
 	);
 }
 

--- a/src/components/collaborative-editing/components/avatars/index.js
+++ b/src/components/collaborative-editing/components/avatars/index.js
@@ -130,7 +130,7 @@ export default compose( [
 
 		return {
 			onAvatarClick( peer ) {
-				if ( peer && peer.start && peer.start.clientId ) {
+				if ( peer?.start?.clientId ) {
 					selectBlock( peer.start.clientId );
 				}
 			},

--- a/src/components/collaborative-editing/components/avatars/index.js
+++ b/src/components/collaborative-editing/components/avatars/index.js
@@ -2,9 +2,10 @@
  * WordPress dependencies
  */
 import { Popover, VisuallyHidden } from '@wordpress/components';
-import { withSelect } from '@wordpress/data';
+import { withSelect, useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -35,6 +36,13 @@ export function CollaborativeEditingAvatars( { peers } ) {
 
 export function CollaborativeEditingAvatar( { peer } ) {
 	const [ isVisible, setIsVisible ] = useState( false );
+	const { selectBlock } = useDispatch( blockEditorStore );
+
+	const focusPeerSelectedBlock = () => {
+		if ( peer && peer.start && peer.start.clientId ) {
+			selectBlock( peer.start.clientId );
+		}
+	};
 
 	return (
 		<div
@@ -42,6 +50,10 @@ export function CollaborativeEditingAvatar( { peer } ) {
 			aria-label={ peer.name }
 			onMouseEnter={ () => setIsVisible( true ) }
 			onMouseLeave={ () => setIsVisible( false ) }
+			tabIndex={ -1 }
+			role="button"
+			onKeyDown={ () => {} }
+			onClick={ focusPeerSelectedBlock }
 			style={ {
 				borderColor: peer.color,
 				background: peer.color,

--- a/src/components/collaborative-editing/components/avatars/style.scss
+++ b/src/components/collaborative-editing/components/avatars/style.scss
@@ -10,7 +10,7 @@ $avatarBorderWidth: 2px;
 	margin: 0 8px;
 }
 
-.iso-editor-collab-avatars__avatar {
+.iso-editor-collab-avatars__avatar-btn {
 	display: flex;
 	justify-content: center;
 	align-items: center;
@@ -19,6 +19,16 @@ $avatarBorderWidth: 2px;
 	border-radius: 50%;
 	border-width: $avatarBorderWidth;
 	border-style: solid;
+
+	// Button reset styles
+	margin: 0;
+	padding: 0;
+	background: transparent;
+	-webkit-appearance: none;
+
+	&:hover {
+		cursor: pointer;
+	}
 
 	& + & {
 		margin-left: -4px;

--- a/src/components/collaborative-editing/components/avatars/style.scss
+++ b/src/components/collaborative-editing/components/avatars/style.scss
@@ -19,12 +19,8 @@ $avatarBorderWidth: 2px;
 	border-radius: 50%;
 	border-width: $avatarBorderWidth;
 	border-style: solid;
-
-	// Button reset styles
-	margin: 0;
 	padding: 0;
-	background: transparent;
-	-webkit-appearance: none;
+	box-sizing: content-box;
 
 	&:hover {
 		cursor: pointer;


### PR DESCRIPTION
Fixes #56.

## Testing instructions

Run storybook with `yarn storybook` (you need to use a workaround from #74 temporarily to get it running). Open two instances of Default Collaboration and create a few blocks in two browser tabs. Click on the avatar of the other peer to select their selected block.

@mirka should we add the pointer cursor to the avatar? Any a11y concerns? Should I move the fn to somewhere else? Also, what should happen in this case: https://github.com/Automattic/isolated-block-editor/issues/56#issuecomment-938048117?