### PR TITLE
Collab: fix changing of caret avatar text color

### DIFF
--- a/src/components/collaborative-editing/use-yjs/formats/collab-caret/index.js
+++ b/src/components/collaborative-editing/use-yjs/formats/collab-caret/index.js
@@ -52,7 +52,7 @@ export function applyCarets( record, carets = [] ) {
 					style: [
 						`--iso-editor-collab-caret-color: ${ color || '#2e3d48' };`,
 						`--iso-editor-collab-caret-label-text-color: ${
-							shouldUseWhiteText( color ) ? '#fff' : 'currentColor'
+							shouldUseWhiteText( color ) ? '#fff' : '#000'
 						};`,
 					].join( ' ' ),
 				},

--- a/src/components/collaborative-editing/use-yjs/formats/collab-caret/index.js
+++ b/src/components/collaborative-editing/use-yjs/formats/collab-caret/index.js
@@ -52,7 +52,7 @@ export function applyCarets( record, carets = [] ) {
 					style: [
 						`--iso-editor-collab-caret-color: ${ color || '#2e3d48' };`,
 						`--iso-editor-collab-caret-label-text-color: ${
-							shouldUseWhiteText( color ) ? '#fff' : '#000'
+							shouldUseWhiteText( color ) ? '#fff' : '#1e1e1e'
 						};`,
 					].join( ' ' ),
 				},


### PR DESCRIPTION
Fixes #63.

Explanation of the problem in https://github.com/Automattic/isolated-block-editor/issues/63#issuecomment-945854723.

## Testing instructions

In order to reproduce the original issue, modify this array of colors https://github.com/Automattic/isolated-block-editor/blob/b7cfe045bd7087be9841ce86a1082dee67a3f574/src/components/collaborative-editing/use-yjs/index.js#L34 with just `#ffffff` (low-contrast color). Run the storybook and open the collab editor story in two tabs so you get a peer. Their name should show with a white background. Select the text below the collab avatar and change its color with the Highlight feature. That should also change the color of the user's label. Now, checkout this PR and repeat the same steps. User's label color should not change, it should stay black.

I've tested this fix with other low-contrast colors like yellow or orange and the black label seems fine.