### PR TITLE
Add fix for CSS override for Gutenberg's static mobile breakpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.8.1] - 2021-12-06
+
+### Fixed
+
+- Fix CSS override to disable Gutenberg's mobile `position: static` - it needs to be important but still allow previews to work
+
 ## [2.8.0] - 2021-12-06
 
 ### Added

--- a/src/style.scss
+++ b/src/style.scss
@@ -6,9 +6,10 @@
 @import '@wordpress/base-styles/_animations';
 @import '@wordpress/base-styles/_z-index';
 
-// Stop Gutenberg preventing mobile scrolling
-html {
-	position: unset;
+// Gutenberg has a global `position: unset` style applied to the editor that is used in the core editor to prevent the page scrolling (it scrolls internally)
+// but that isn't suitable for other situations. We need to remove that.
+html.interface-interface-skeleton__html-container {
+	position: unset !important;
 }
 
 .components-modal__frame,


### PR DESCRIPTION
Gutenberg adds a `position: static` to the page to stop it scrolling, but that's only relevant when the editor is full page like it is in Gutenberg. Ideally this is left up to the client.

We need to override this as it's not possible to scroll the page at all otherwise.

We still want the static position when viewing previews, otherwise Gutenberg can't calculate the height.