### PR TITLE
Add renovate config for @wordpress packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,20 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": [ "config:base" ],
+	"enabledManagers": [ "npm" ],
+	"lockFileMaintenance": {
+		"enabled": false
+	},
+	"packageRules": [
+		{
+			"matchPackagePatterns": [ "*" ],
+			"enabled": false
+		},
+		{
+			"matchPackagePatterns": [ "^@wordpress" ],
+			"enabled": true,
+			"matchDepTypes": [ "dependencies" ],
+			"separateMajorMinor": false
+		}
+	]
+}


### PR DESCRIPTION
Closes #93 

First attempt at adding minimal Renovate config to update `@wordpress` dependencies (excludes `devDependencies`). Let's see if I got it right on the first try 😄 