### PR TITLE
Renovate: Disable dependency dashboard

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,7 @@
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": [ "config:base" ],
 	"enabledManagers": [ "npm" ],
+	"dependencyDashboard": false,
 	"lockFileMaintenance": {
 		"enabled": false
 	},


### PR DESCRIPTION
Closes #100

We won't be needing the Dependency Dashboard.