### PR TITLE
Collab: Tweak flakey test

### DIFF
--- a/src/components/collaborative-editing/use-yjs/__tests__/index.js
+++ b/src/components/collaborative-editing/use-yjs/__tests__/index.js
@@ -107,19 +107,15 @@ describe( 'CollaborativeEditing', () => {
 		expect( bobScreen.getByRole( 'document', { name: 'Paragraph block' } ) ).toHaveTextContent( 'hello' );
 		expect( bobScreen.getByTitle( 'Alice' ) ).toHaveTextContent( 'o' ); // peer caret
 
-		userEvent.keyboard( 'world' );
+		userEvent.keyboard( '!' );
 
-		expect( aliceScreen.getByRole( 'document', { name: 'Paragraph block' } ) ).toHaveTextContent( 'helloworld' );
-		expect( bobScreen.getByRole( 'document', { name: 'Paragraph block' } ) ).toHaveTextContent( 'helloworld' );
+		expect( aliceScreen.getByRole( 'document', { name: 'Paragraph block' } ) ).toHaveTextContent( 'hello!' );
+		expect( bobScreen.getByRole( 'document', { name: 'Paragraph block' } ) ).toHaveTextContent( 'hello!' );
 
-		expect( aliceScreen.getByTitle( 'Bob' ) ).toHaveTextContent( 'd' ); // peer caret
+		expect( aliceScreen.getByTitle( 'Bob' ) ).toHaveTextContent( '!' ); // peer caret
 
-		expect( onSave1 ).toHaveBeenLastCalledWith(
-			'<!-- wp:paragraph -->\n<p>helloworld</p>\n<!-- /wp:paragraph -->'
-		);
-		expect( onSave2 ).toHaveBeenLastCalledWith(
-			'<!-- wp:paragraph -->\n<p>helloworld</p>\n<!-- /wp:paragraph -->'
-		);
+		expect( onSave1 ).toHaveBeenLastCalledWith( '<!-- wp:paragraph -->\n<p>hello!</p>\n<!-- /wp:paragraph -->' );
+		expect( onSave2 ).toHaveBeenLastCalledWith( '<!-- wp:paragraph -->\n<p>hello!</p>\n<!-- /wp:paragraph -->' );
 	} );
 
 	it( 'should work with initial onLoad content', async () => {


### PR DESCRIPTION
Due to the way that block editor (`contenteditable`) interactions are not fully testable with jsdom, this UI test is particularly susceptible to race conditions that only affect this test environment.

This tweak makes it less sensitive to these race conditions, while still testing what we intended to.