### PR TITLE
Collab: Fix caret position for undo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.12.1] - Unreleased
+
+### Fixed
+
+- Fix caret position when undoing in collab mode.
+
 ## [2.12.0] - 2022-04-15
 
 ### Added

--- a/src/components/collaborative-editing/use-yjs/yjs-undo.js
+++ b/src/components/collaborative-editing/use-yjs/yjs-undo.js
@@ -46,10 +46,7 @@ export function setupUndoManager( typeScope, identity, registry ) {
 			return;
 		}
 
-		// For undos, we want to get the caret position associated with the next item in the stack
-		const selectionReferenceItem =
-			event.type === 'undo' ? undoManager.undoStack[ undoManager.undoStack.length - 1 ] : event.stackItem;
-		const selection = selectionReferenceItem.meta.get( 'caret-location' );
+		const selection = event.stackItem.meta.get( 'caret-location' );
 
 		if ( selection?.start ) {
 			setSelection( selection );


### PR DESCRIPTION
Caret positions on undo regressed at some point. This PR fixes the restoration of caret positions after undo actions.

Unfortunately this is not really testable in jsdom (#129). 

## To test

1. `yarn storybook` and go to the collab editor story.
2. Type "hello", pause for a second or so, then type "world".
3. Undo.
4. Your caret should be positioned after the word "hello", as expected.