### PR TITLE
Rename fetchLinkSuggestions

### DIFF
--- a/src/components/default-settings/index.js
+++ b/src/components/default-settings/index.js
@@ -134,9 +134,9 @@ export default function applyDefaultSettings( settings ) {
 
 			// Default to no link suggestions
 			// @ts-ignore */}
-			__experimentalFetchLinkSuggestions: editor?.__experimentalFetchLinkSuggestions
+			fetchLinkSuggestions: editor?.fetchLinkSuggestions ?? editor?.__experimentalFetchLinkSuggestions
 				? // @ts-ignore */}
-				  editor?.__experimentalFetchLinkSuggestions
+				  editor?.fetchLinkSuggestions ?? editor?.__experimentalFetchLinkSuggestions
 				: () => [],
 		},
 	};


### PR DESCRIPTION
Fixes the breaking Gutenberg change https://github.com/WordPress/gutenberg/pull/40052, see also https://github.com/Automattic/gutenberg-everywhere/issues/25

### Description
`__experimentalFetchLinkSuggestions` is being renamed to `fetchLinkSuggestions`

### Solution
I've renamed the function call which was already written in a defensive matter. I've changed the code so that it falls back to a potentially existing `__experimentalFetchLinkSuggestions` but maybe this is not necessary. I haven't seen this being called anywhere in the codebase.

cc @getdave 