### PR TITLE
Add a title slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.13.0] - Unreleased
 
+### Added
+
+- Add EditorHeadingSlot to allow content to be inserted before the editor. For example, a title.
+
 ### Fixed
 
 - Duplicate interface store to fix problem with different context stopping block inspector from working

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ The `IsolatedBlockEditor` also exports the following support components:
 - `DocumentSection` - Wrap up a component to appear in the document tab of the inspector
 - `ToolbarSlot` - Insert content into the toolbar
 - `FooterSlot` - Insert content into the footer
+- `EditorHeadingSlot` - Insert content at the beginning of the editor area. Suitable for titles.
 - [`CollaborativeEditing`](https://github.com/Automattic/isolated-block-editor/tree/trunk/src/components/collaborative-editing) - Enable real-time collaborative editing
 
 ```js

--- a/src/components/block-editor/text-editor.js
+++ b/src/components/block-editor/text-editor.js
@@ -7,6 +7,7 @@ import React from 'react';
  * Internal dependencies
  */
 import PostTextEditor from './post-text-editor';
+import EditorHeading from '../editor-heading-slot';
 
 /**
  * This is a copy of packages/edit-post/src/components/text-editor/index.js
@@ -17,6 +18,7 @@ function TextEditor( {} ) {
 	return (
 		<div className="edit-post-text-editor">
 			<div className="edit-post-text-editor__body">
+				<EditorHeading.Slot mode="text" />
 				<PostTextEditor />
 			</div>
 		</div>

--- a/src/components/block-editor/visual-editor.js
+++ b/src/components/block-editor/visual-editor.js
@@ -28,6 +28,11 @@ import { __unstableMotion as motion } from '@wordpress/components';
 import { useRef, useMemo } from '@wordpress/element';
 import { useMergeRefs } from '@wordpress/compose';
 
+/**
+ * Internal dependencies
+ */
+import EditorHeading from '../editor-heading-slot';
+
 function MaybeIframe( { children, contentRef, shouldIframe, styles, style } ) {
 	const ref = useMouseMoveTypingReset();
 
@@ -137,6 +142,7 @@ const VisualEditor = ( { styles } ) => {
 							selector=".edit-post-visual-editor__post-title-wrapper, .block-editor-block-list__layout.is-root-container"
 							layout={ defaultLayout }
 						/>
+						<EditorHeading.Slot mode="visual" />
 						<BlockList className={ undefined } __experimentalLayout={ layout } />
 					</MaybeIframe>
 				</motion.div>

--- a/src/components/editor-heading-slot/index.js
+++ b/src/components/editor-heading-slot/index.js
@@ -1,0 +1,13 @@
+import { createSlotFill } from '@wordpress/components';
+
+const { Fill, Slot } = createSlotFill( 'IsolatedEditorHeading' );
+
+const EditorHeading = ( { children } ) => {
+	return <Fill>{ children }</Fill>;
+};
+
+EditorHeading.Slot = function ( props ) {
+	return <Slot>{ ( fills ) => fills }</Slot>;
+};
+
+export default EditorHeading;

--- a/src/components/footer-slot/index.js
+++ b/src/components/footer-slot/index.js
@@ -9,7 +9,7 @@ const FooterSection = ( { children } ) => {
 	return <Fill>{ children }</Fill>;
 };
 
-FooterSection.Slot = function ( props ) {
+FooterSection.Slot = function( props ) {
 	return <Slot>{ ( fills ) => fills }</Slot>;
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,7 @@ import FooterSlot from './components/footer-slot';
 
 // Export library components
 import EditorLoaded from './components/editor-loaded';
+import EditorHeadingSlot from './components/editor-heading-slot';
 
 // A fake edit-post store is needed
 import './store/edit-post';
@@ -225,4 +226,4 @@ function IsolatedBlockEditor( props ) {
 
 export default withRegistryProvider( IsolatedBlockEditor );
 
-export { EditorLoaded, DocumentSection, ToolbarSlot, CollaborativeEditing, FooterSlot };
+export { EditorLoaded, DocumentSection, ToolbarSlot, CollaborativeEditing, FooterSlot, EditorHeadingSlot };


### PR DESCRIPTION
This adds a `EditorHeadingSlot` component that can be used to insert content into the head of the editor content. This makes it useful for things such as a title field.