### PR TITLE
Use optional chaining (?.) for conditional call

### DIFF
--- a/src/components/content-saver/index.js
+++ b/src/components/content-saver/index.js
@@ -30,8 +30,8 @@ function ContentSaver( props ) {
 
 	function saveBlocks() {
 		// Save the content in the format wanted by the user
-		onSaveBlocks && onSaveBlocks( blocks, ignoredContent );
-		onSaveContent && onSaveContent( serialize( blocks ) );
+		onSaveBlocks?.( blocks, ignoredContent );
+		onSaveContent?.( serialize( blocks ) );
 	}
 
 	useEffect( () => {


### PR DESCRIPTION
This is just a small tweak to fix the linting error showing in these two lines:

`Expected an assignment or function call and instead saw an expression.eslint[no-unused-expressions](https://eslint.org/docs/rules/no-unused-expressions)` 


