### PR TITLE
Add more debug logs for undo feature

### DIFF
--- a/src/components/collaborative-editing/use-yjs/index.js
+++ b/src/components/collaborative-editing/use-yjs/index.js
@@ -69,6 +69,7 @@ async function initYDoc( { settings, registry } ) {
 
 	doc.onConnectionReady(
 		once( () => {
+			debug( 'Connection ready. Setting up ydoc document and undo manager' );
 			dispatch( 'isolated/editor' ).setYDoc( doc );
 			setupUndoManager( doc.getPostMap(), identity, registry );
 		} )

--- a/src/components/content-saver/index.js
+++ b/src/components/content-saver/index.js
@@ -30,8 +30,8 @@ function ContentSaver( props ) {
 
 	function saveBlocks() {
 		// Save the content in the format wanted by the user
-		onSaveBlocks && onSaveBlocks( blocks, ignoredContent );
-		onSaveContent && onSaveContent( serialize( blocks ) );
+		onSaveBlocks?.( blocks, ignoredContent );
+		onSaveContent?.( serialize( blocks ) );
 	}
 
 	useEffect( () => {

--- a/src/store/collab/controls.js
+++ b/src/store/collab/controls.js
@@ -58,8 +58,10 @@ export default {
 		const undoManager = registry.select( 'isolated/editor' ).getUndoManager();
 
 		if ( ! undoManager ) {
+			debugUndo( 'Undoing from redux-undo state' );
 			return action;
 		}
+		debugUndo( 'Undoing from yjs undoManager' );
 
 		debugUndo( 'undo' );
 		undoManager.undo();


### PR DESCRIPTION
This Pull Request adds a few more logs to provide visibility on the timing of undo events such as switching to the yjs undo system from redux-undo and to track where a given undo is coming from.

The intention is to be able to understand better the behaviour of this feature (and the underlying system switch) on slow connections, websocket connection drops, reconnections, etc.
