### PR TITLE
Initialize collab document and undo as early as possible

### DIFF
--- a/src/components/collaborative-editing/use-yjs/index.js
+++ b/src/components/collaborative-editing/use-yjs/index.js
@@ -3,7 +3,7 @@
  */
 import { createMutex } from 'lib0/mutex';
 import { v4 as uuidv4 } from 'uuid';
-import { noop, once, sample } from 'lodash';
+import { noop, sample } from 'lodash';
 
 /**
  * Internal dependencies
@@ -67,13 +67,9 @@ async function initYDoc( { settings, registry } ) {
 		},
 	} );
 
-	doc.onConnectionReady(
-		once( () => {
-			debug( 'Connection ready. Setting up ydoc document and undo manager' );
-			dispatch( 'isolated/editor' ).setYDoc( doc );
-			setupUndoManager( doc.getPostMap(), identity, registry );
-		} )
-	);
+	debug( 'Collab enabled. Setting up ydoc document and undo manager' );
+	dispatch( 'isolated/editor' ).setYDoc( doc );
+	setupUndoManager( doc.getPostMap(), identity, registry );
 
 	doc.onYDocTriggeredChange( ( changes ) => {
 		debug( 'changes triggered by ydoc, applying to editor state', changes );


### PR DESCRIPTION
fixes https://github.com/Automattic/isolated-block-editor/issues/136

## Description

This pull request changes the yjs document and undo manager setup so that it happens as soon as the feature is enabled, instead of once the the connection is ready.

Doing it this way, allows for building up the history and syncing the yjs document even if the connection cannot be stablished, or if the connection happens at a later time due to a poor internet connection.

## Testing

First, Start by reproducing the problem (by checking out trunk, instead of this branch)

1. Access any sandboxed instance of the editor (such as a P2 post).
2. On the browser's dev tools, enable logging with: `localStorage.setItem("debug", "iso-editor:*")`
3. Make sure you have "verbose logs" active, otherwise you won't see these logs:. 
    <img width="197" alt="image" src="https://user-images.githubusercontent.com/1574407/170215066-9232478b-25fb-456e-b513-3bfc9614ed45.png">
4. On the browser's dev tools, set network throttling to "Slow 3G"
5. Reload the page, and as soon as the editor starts accepting input, quickly type a few characters, and hit CMD+z for undoing. Keep doing this repeatedly until the editor is fully loaded, and the WebSocket connections are up.

At this point you will notice the problem in the debug logs, the first few "undos" before the connection was up, will read as `Undoing from redux-undo state` and at some point, after the WebSocket connection is stablished, the messages will become `Undoing from yjs undoManager`.

This means that any redo buffers (up to now, stored in redux-undo) we might have by the time the connection is ready will become inaccessible due to the undo system change, which I think is at least part of the general data loss problem we're investigating (Imagine a user that due to network/proxy issues cannot connect to the WebSocket, and due to some system or network change suddenly connects 20m later).


Finally, check out this branch, and repeat the testing process. There should be no single instance of `Undoing from redux-undo state` logs, because even before the WebSocket connection is active, we're already updating the yjs document and tracking do/undo events with yjs' own undo system.




