### PR TITLE
Remove fullscreen if component unmounted

### DIFF
--- a/src/components/block-editor/index.js
+++ b/src/components/block-editor/index.js
@@ -132,6 +132,10 @@ function BlockEditor( props ) {
 			// @ts-ignore
 			document.querySelector( 'html' ).classList.remove( 'is-fullscreen-mode' );
 		}
+
+		return () => {
+			document.querySelector( 'html' ).classList.remove( 'is-fullscreen-mode' );
+		};
 	}, [ isFullscreenActive ] );
 
 	return (

--- a/src/components/block-editor/index.js
+++ b/src/components/block-editor/index.js
@@ -125,16 +125,20 @@ function BlockEditor( props ) {
 
 	// For back-compat with older iso-editor
 	useEffect( () => {
+		const html = document.querySelector( 'html' );
+
 		if ( isFullscreenActive ) {
 			// @ts-ignore
-			document.querySelector( 'html' ).classList.add( 'is-fullscreen-mode' );
+			html.classList.add( 'is-fullscreen-mode' );
 		} else {
 			// @ts-ignore
-			document.querySelector( 'html' ).classList.remove( 'is-fullscreen-mode' );
+			html.classList.remove( 'is-fullscreen-mode' );
 		}
 
 		return () => {
-			document.querySelector( 'html' ).classList.remove( 'is-fullscreen-mode' );
+			if ( html ) {
+				html.classList.remove( 'is-fullscreen-mode' );
+			}
 		};
 	}, [ isFullscreenActive ] );
 


### PR DESCRIPTION
Even though this component is marked for removal this fixes a problem where the fullscreen body class remains if the component is unmounted before fullscreen is disabled.
