### PR TITLE
Fix the block inserter showing mobile viewport UI

### DIFF
--- a/src/components/block-editor/inserter-sidebar.js
+++ b/src/components/block-editor/inserter-sidebar.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useDispatch } from '@wordpress/data';
-import { Button } from '@wordpress/components';
+import { Button, VisuallyHidden } from '@wordpress/components';
 import { __experimentalLibrary as Library } from '@wordpress/block-editor';
 import { close } from '@wordpress/icons';
 import { useViewportMatch, __experimentalUseDialog as useDialog } from '@wordpress/compose';
@@ -10,10 +10,12 @@ import { useViewportMatch, __experimentalUseDialog as useDialog } from '@wordpre
 export default function InserterSidebar() {
 	const { setIsInserterOpened } = useDispatch( 'isolated/editor' );
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
+	const TagName = ! isMobileViewport ? VisuallyHidden : 'div';
 	// Note: focusOnMount not present in Gutenberg
 	// @ts-ignore
 	const [ inserterDialogRef, inserterDialogProps ] = useDialog( {
 		onClose: () => setIsInserterOpened( false ),
+		focusOnMount: null,
 	} );
 
 	return (
@@ -23,9 +25,9 @@ export default function InserterSidebar() {
 			{ ...inserterDialogProps }
 			className="edit-post-editor__inserter-panel"
 		>
-			<div className="edit-post-editor__inserter-panel-header">
+			<TagName className="edit-post-editor__inserter-panel-header">
 				<Button icon={ close } onClick={ () => setIsInserterOpened( false ) } />
-			</div>
+			</TagName>
 			<div className="edit-post-editor__inserter-panel-content">
 				<Library showMostUsedBlocks={ false } showInserterHelpPanel shouldFocusBlock={ isMobileViewport } />
 			</div>

--- a/src/components/block-editor/inserter-sidebar.js
+++ b/src/components/block-editor/inserter-sidebar.js
@@ -15,6 +15,7 @@ export default function InserterSidebar() {
 	// @ts-ignore
 	const [ inserterDialogRef, inserterDialogProps ] = useDialog( {
 		onClose: () => setIsInserterOpened( false ),
+		// @ts-ignore copied from Gutenberg
 		focusOnMount: null,
 	} );
 


### PR DESCRIPTION
The full height block inserter is showing a big X at the top:

![image](https://user-images.githubusercontent.com/1277682/173792328-78ab2060-6b20-431f-aaeb-101b662d81f8.png)

This should only appear on the mobile viewport and it's appearing here because we need to wrap it in a `VisuallyHidden`, dependant on whether this is a mobile viewport.

It should look like:

![image](https://user-images.githubusercontent.com/1277682/173792471-d75bdf18-ea77-4697-94dd-f3afe995cb60.png)
