### PR TITLE
Keep internal state in sync when onChange and onInput are called

### DIFF
--- a/src/components/block-editor-container/index.js
+++ b/src/components/block-editor-container/index.js
@@ -53,24 +53,12 @@ const SIZE_MEDIUM = 480;
  * @param {OnMore} props.renderMoreMenu - Callback to render additional items in the more menu
  * @param {OnSetEditing} props.setEditing - Set the mode to editing
  * @param {OnLoad} props.onLoad - Load initial blocks
- * @param {OnUpdate} props.updateBlocksWithoutUndo - Callback to update blocks
  * @param {OnUpdate} [props.onInput] - Gutenberg's onInput callback
  * @param {OnUpdate} [props.onChange] - Gutenberg's onChange callback
  * @param {object[]} [props.blocks] - Gutenberg's blocks
  */
 function BlockEditorContainer( props ) {
-	const {
-		children,
-		settings,
-		className,
-		onError,
-		renderMoreMenu,
-		onLoad,
-		onInput,
-		onChange,
-		blocks,
-		updateBlocksWithoutUndo,
-	} = props;
+	const { children, settings, className, onError, renderMoreMenu, onLoad, onInput, onChange, blocks } = props;
 	const { isEditorReady, editorMode, isEditing, setEditing, hasFixedToolbar, isPreview } = props;
 	const [ resizeListener, { width } ] = useResizeObserver();
 	const classes = classnames( className, {
@@ -91,13 +79,6 @@ function BlockEditorContainer( props ) {
 		'is-preview-mode': isPreview,
 	} );
 
-	useEffect( () => {
-		// If blocks are externally provided, update the internal state
-		if ( blocks ) {
-			updateBlocksWithoutUndo( blocks, {} );
-		}
-	}, [ blocks ] );
-
 	return (
 		<div className={ classes }>
 			<ErrorBoundary onError={ onError }>
@@ -110,6 +91,7 @@ function BlockEditorContainer( props ) {
 					onFocus={ () => ! isEditing && setEditing( true ) }
 				>
 					<BlockEditorContents
+						blocks={ blocks }
 						settings={ settings }
 						renderMoreMenu={ renderMoreMenu }
 						onLoad={ onLoad }
@@ -139,11 +121,10 @@ export default compose( [
 		};
 	} ),
 	withDispatch( ( dispatch ) => {
-		const { setEditing, updateBlocksWithoutUndo } = dispatch( 'isolated/editor' );
+		const { setEditing } = dispatch( 'isolated/editor' );
 
 		return {
 			setEditing,
-			updateBlocksWithoutUndo,
 		};
 	} ),
 ] )( BlockEditorContainer );

--- a/src/components/block-editor-container/index.js
+++ b/src/components/block-editor-container/index.js
@@ -10,7 +10,6 @@ import classnames from 'classnames';
 import { compose, useResizeObserver } from '@wordpress/compose';
 import { ErrorBoundary } from '@wordpress/editor';
 import { withDispatch, withSelect } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/src/components/block-editor-contents/index.js
+++ b/src/components/block-editor-contents/index.js
@@ -113,11 +113,10 @@ function BlockEditorContents( props ) {
 }
 
 export default compose( [
-	withSelect( ( select ) => {
+	withSelect( ( select, ownProps ) => {
 		const { getBlocks, getEditorSelection, getEditorMode, isEditing } = select( 'isolated/editor' );
-
 		return {
-			blocks: getBlocks(),
+			blocks: ownProps.blocks ?? getBlocks(),
 			selection: getEditorSelection(),
 			isEditing: isEditing(),
 			editorMode: getEditorMode(),
@@ -128,8 +127,14 @@ export default compose( [
 		const { onInput, onChange } = ownProps;
 
 		return {
-			onChange: onChange ?? updateBlocksWithUndo,
-			onInput: onInput ?? updateBlocksWithoutUndo,
+			onChange: ( ...args ) => {
+				onChange?.( ...args );
+				updateBlocksWithUndo( ...args );
+			},
+			onInput: ( ...args ) => {
+				onInput?.( ...args );
+				updateBlocksWithoutUndo( ...args );
+			},
 		};
 	} ),
 ] )( BlockEditorContents );

--- a/src/components/block-editor/index.js
+++ b/src/components/block-editor/index.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { withDispatch } from '@wordpress/data';
+import { withDispatch, useSelect } from '@wordpress/data';
 import { KeyboardShortcuts } from '@wordpress/components';
 import { rawShortcut } from '@wordpress/keycodes';
 import { useViewportMatch } from '@wordpress/compose';
@@ -14,7 +14,6 @@ import { BlockEditorKeyboardShortcuts } from '@wordpress/block-editor';
 import { EditorNotices, EditorSnackbars } from '@wordpress/editor';
 import { FullscreenMode, ComplementaryArea, InterfaceSkeleton, store as interfaceStore } from '@wordpress/interface';
 import { __, _x } from '@wordpress/i18n';
-import { useSelect } from '@wordpress/data';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { useEffect } from '@wordpress/element';
 


### PR DESCRIPTION
I've found (the hard way) that not calling `updateBlocksWithUndo` and/or `updateBlocksWithoutUndo` when `onChange` and/or `onInput` are provided causes the internal state of the editor to get out of sync, so things such as  `const { getPostEdits } = select( 'core/editor' )` stop working (not finding any edits).

This PR changes the previous behaviour I introduced (replacing these default handlers with the custom ones) by instead calling both, the externally provided one so that external callers can "detect" when changes/input happen but still keeps the default functionality.