### PR TITLE
Fix styles in the count's table content

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ If you are not using on a WordPress site then you will need to load the core CSS
 Alternatively you can directly import the bundled `build-browser/core.css` CSS:
 
 ```js
-import 'isolated-block-editor/build-browser/core.css';
+import '@automatic/isolated-block-editor/build-browser/core.css';
 ```
 
 ## Using
@@ -150,7 +150,7 @@ Include the `IsolatedBlockEditor` module and then create an instance:
 
 ```js
 
-import IsolatedBlockEditor from 'isolated-block-editor';
+import IsolatedBlockEditor from '@automatic/isolated-block-editor';
 
 render(
 	<IsolatedBlockEditor

--- a/src/style.scss
+++ b/src/style.scss
@@ -1,10 +1,9 @@
-
-@import '@wordpress/base-styles/_colors';
-@import '@wordpress/base-styles/_variables';
-@import '@wordpress/base-styles/_mixins';
-@import '@wordpress/base-styles/_breakpoints';
-@import '@wordpress/base-styles/_animations';
-@import '@wordpress/base-styles/_z-index';
+@import "@wordpress/base-styles/_colors";
+@import "@wordpress/base-styles/_variables";
+@import "@wordpress/base-styles/_mixins";
+@import "@wordpress/base-styles/_breakpoints";
+@import "@wordpress/base-styles/_animations";
+@import "@wordpress/base-styles/_z-index";
 
 // Gutenberg has a global `position: unset` style applied to the editor that is used in the core editor to prevent the page scrolling (it scrolls internally)
 // but that isn't suitable for other situations. We need to remove that.
@@ -34,7 +33,7 @@ html.interface-interface-skeleton__html-container {
 		-webkit-box-sizing: border-box;
 	}
 
-	p:not( .components-form-token-field__help ) {
+	p:not(.components-form-token-field__help) {
 		font-size: inherit;
 		line-height: inherit;
 	}
@@ -52,6 +51,20 @@ html.interface-interface-skeleton__html-container {
 
 	ul {
 		list-style-type: none;
+	}
+
+	ul.table-of-contents__counts {
+		margin: 0;
+		padding: 0.2rem 0.5rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.2rem;
+	}
+
+	ul.table-of-contents__counts > li {
+		display: flex;
+		justify-content: space-between;
+		gap: 0.5rem;
 	}
 
 	ol {


### PR DESCRIPTION
Hey, I was checking out some features and I've realized that the styles from the count's are bit broken as you can see in the next image.
![image](https://user-images.githubusercontent.com/65885753/176439493-4e7cc390-f791-4b55-ba1e-51c0bb0ffca6.png)

I've added some specific style targeting the class table-of-contents__counts to fix it as you can see in the following picture:
![fixstyles-toc](https://user-images.githubusercontent.com/65885753/176439849-178fffc1-d1b4-4576-86b2-b4d6db70d194.png)

I don't know how but in the pull request it's also trying to add the commit I did earlier, to be honest I'm new in this pull request's things working in another repositories, I hope it's not much trouble and I'm sorry for that.

I wanted to say as well thanks for developing this isolated Gutenberg, I was in the process of implementing it myself directly from the Gutenberg repository but the features added here are just wholesome. 

Thanks again!
