### PR TITLE
Remove unused and missing experimental import: `__experimentalBlockSettingsMenuFirstItem`

### DIFF
--- a/src/components/block-editor/visual-editor.js
+++ b/src/components/block-editor/visual-editor.js
@@ -17,7 +17,6 @@ import {
 	__unstableUseTypewriter as useTypewriter,
 	__unstableUseClipboardHandler as useClipboardHandler,
 	__unstableUseTypingObserver as useTypingObserver,
-	__experimentalBlockSettingsMenuFirstItem,
 	__experimentalUseResizeCanvas as useResizeCanvas,
 	__unstableUseMouseMoveTypingReset as useMouseMoveTypingReset,
 	__unstableIframe as Iframe,


### PR DESCRIPTION
@orballo and I were testing this with Vite (which, by the way, seems to be working fine), but it returns this error:

```
No matching export in "node_modules/@wordpress/block-editor/build-module/index.js" for import "__experimentalBlockSettingsMenuFirstItem"
```

As `__experimentalBlockSettingsMenuFirstItem` is an experimental API and it's not used in the file where it is imported, I figured it's fine to remove it. I can't find it in Gutenberg anymore: https://github.com/WordPress/gutenberg/search?q=__experimentalBlockSettingsMenuFirstItem
