### PR TITLE
Add a new boolean 'header' setting so that it can be disabled when not needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.17.0] - 2022-08-04
+- Add a new boolean 'header' setting so that it can be disabled when not neede
+
 ## [2.16.0] - 2022-06-30
 - Fixed the deprecated use of BlockNavigationDropdown
 - Remove some old CSS adding focus borders to some blocks

--- a/src/components/block-editor/index.js
+++ b/src/components/block-editor/index.js
@@ -73,6 +73,7 @@ function BlockEditor( props ) {
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const inspectorInSidebar = settings?.iso?.sidebar?.inspector || false;
 	const inserterInSidebar = settings?.iso?.sidebar?.inserter || false;
+	const showHeader = settings?.iso?.header ?? true;
 	const showFooter = settings?.iso?.footer || false;
 	const {
 		sidebarIsOpened,
@@ -141,6 +142,10 @@ function BlockEditor( props ) {
 		};
 	}, [ isFullscreenActive ] );
 
+	const header = showHeader ? (
+		<BlockEditorToolbar editorMode={ editorMode } settings={ settings } renderMoreMenu={ renderMoreMenu } />
+	) : null;
+
 	return (
 		<>
 			<SettingsSidebar documentInspector={ settings?.iso?.toolbar?.documentInspector ?? false } />
@@ -149,13 +154,7 @@ function BlockEditor( props ) {
 			<InterfaceSkeleton
 				className={ className }
 				labels={ interfaceLabels }
-				header={
-					<BlockEditorToolbar
-						editorMode={ editorMode }
-						settings={ settings }
-						renderMoreMenu={ renderMoreMenu }
-					/>
-				}
+				header={ header }
 				secondarySidebar={ secondarySidebar() }
 				sidebar={
 					( ! isMobileViewport || sidebarIsOpened ) &&

--- a/src/components/default-settings/index.js
+++ b/src/components/default-settings/index.js
@@ -57,6 +57,8 @@ export default function applyDefaultSettings( settings ) {
 				...( iso?.toolbar ?? {} ),
 			},
 
+			header: iso?.header ?? true,
+
 			sidebar: {
 				inserter: false,
 				inspector: false,

--- a/src/index.js
+++ b/src/index.js
@@ -92,6 +92,7 @@ import './style.scss';
  * @property {string[]} [disallowEmbed] - List of embed names to remove
  * @property {object[]} [customStores] - Array of custom stores
  * @property {boolean} [footer] - Show footer component
+ * @property {boolean} [header] - Show header component
  * @property {ToolbarSettings} [toolbar] - Toolbar settings
  * @property {MoreMenuSettings|false} [moreMenu] - More menu settings, or false to disable
  * @property {{title: string, url: string}[]} [linkMenu] - Link menu settings


### PR DESCRIPTION
This Pull Request adds a new boolean setting named `iso.header` (default: `true`). 

When this setting is set to `false` the editor will not show the default header.
