### PR TITLE
Add 'constrained' type to default layout to support latest Gutenberg

### DIFF
--- a/src/components/block-editor/visual-editor.js
+++ b/src/components/block-editor/visual-editor.js
@@ -116,7 +116,7 @@ const VisualEditor = ( { styles } ) => {
 
 	const layout = useMemo( () => {
 		if ( themeSupportsLayout ) {
-			return { ...defaultLayout, type: 'constrained' };
+			return defaultLayout;
 		}
 
 		return undefined;
@@ -140,7 +140,7 @@ const VisualEditor = ( { styles } ) => {
 					>
 						<LayoutStyle
 							selector=".edit-post-visual-editor__post-title-wrapper, .block-editor-block-list__layout.is-root-container"
-							layout={ layout }
+							layout={ { ...defaultLayout, type: 'constrained' } }
 						/>
 						<EditorHeading.Slot mode="visual" />
 						<BlockList className={ undefined } __experimentalLayout={ layout } />

--- a/src/components/block-editor/visual-editor.js
+++ b/src/components/block-editor/visual-editor.js
@@ -116,7 +116,7 @@ const VisualEditor = ( { styles } ) => {
 
 	const layout = useMemo( () => {
 		if ( themeSupportsLayout ) {
-			return defaultLayout;
+			return { ...defaultLayout, type: 'constrained' };
 		}
 
 		return undefined;
@@ -140,7 +140,7 @@ const VisualEditor = ( { styles } ) => {
 					>
 						<LayoutStyle
 							selector=".edit-post-visual-editor__post-title-wrapper, .block-editor-block-list__layout.is-root-container"
-							layout={ defaultLayout }
+							layout={ layout }
 						/>
 						<EditorHeading.Slot mode="visual" />
 						<BlockList className={ undefined } __experimentalLayout={ layout } />


### PR DESCRIPTION
[Latest Gutenberg changes](https://github.com/WordPress/gutenberg/commit/93e29bbe5ff854b59f1aa1841b505281aaeabd7d) require the layout to have a `constrained` type to keep the behaviour we had in the iso editor.

This PR adds it so the editor looks as before on newer Gutenberg versions.

