### PR TITLE
Support both gutenberg v13 and v14 layout margins

### DIFF
--- a/src/components/block-editor/visual-editor.js
+++ b/src/components/block-editor/visual-editor.js
@@ -122,6 +122,10 @@ const VisualEditor = ( { styles } ) => {
 		return undefined;
 	}, [ themeSupportsLayout, defaultLayout ] );
 
+	// If there is a layout definition, then we're on Gutenberg > v14, which requires us to pass the
+	// 'constrained' type
+	const usedLayout = layout?.definitions ? { ...layout, type: 'constrained' } : layout;
+
 	return (
 		<BlockTools __unstableContentRef={ ref } className="edit-post-visual-editor">
 			<motion.div
@@ -140,7 +144,7 @@ const VisualEditor = ( { styles } ) => {
 					>
 						<LayoutStyle
 							selector=".edit-post-visual-editor__post-title-wrapper, .block-editor-block-list__layout.is-root-container"
-							layout={ { ...defaultLayout, type: 'constrained' } }
+							layout={ usedLayout }
 						/>
 						<EditorHeading.Slot mode="visual" />
 						<BlockList className={ undefined } __experimentalLayout={ layout } />


### PR DESCRIPTION
This pull request fixes an issue introduced in [the previous one](https://github.com/Automattic/isolated-block-editor/pull/182), which caused the missing margins to show correctly on Gutenberg v14 but not on v13.

With these changes, it should work correctly on both.

