### PR TITLE
Update Visual Editor to support custom preview devices/styles

### DIFF
--- a/src/store/editor/actions.js
+++ b/src/store/editor/actions.js
@@ -76,6 +76,19 @@ const actions = {
 		};
 	},
 	/**
+	 * Set the preview device style
+	 *
+	 * @param {string} deviceType
+	 * @param {string} style
+	 */
+	setDeviceStyle( deviceType, style ) {
+		return {
+			type: 'SET_DEVICE_STYLE',
+			deviceType,
+			style,
+		};
+	},
+	/**
 	 * Mark this editor as in-use or not
 	 *
 	 * @param {boolean} isEditing

--- a/src/store/editor/reducer.js
+++ b/src/store/editor/reducer.js
@@ -38,6 +38,7 @@ const getPattern = ( patterns, currentPattern ) =>
  * @property {boolean} isReady - is the editor ready?
  * @property {IsoSettings} settings - editor settings
  * @property {string} deviceType - current device type
+ * @property {Object} deviceStyle - preview device style
  */
 
 /** @type EditorState */
@@ -55,6 +56,7 @@ const DEFAULT_STATE = {
 
 	ignoredContent: [],
 	deviceType: 'Desktop',
+	deviceStyle: {},
 
 	settings: {
 		preferencesKey: null,
@@ -191,6 +193,15 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 			return {
 				...state,
 				deviceType: action.deviceType,
+			};
+
+		case 'SET_DEVICE_STYLE':
+			return {
+				...state,
+				deviceStyle: {
+					...state.deviceStyle,
+					[ action.deviceType ]: action.style,
+				},
 			};
 	}
 

--- a/src/store/editor/selectors.js
+++ b/src/store/editor/selectors.js
@@ -164,3 +164,13 @@ export function isListViewOpened( state ) {
 export function getPreviewDeviceType( state ) {
 	return state.editor.deviceType;
 }
+
+/**
+ * Return current device type
+ *
+ * @param {{editor: EditorState}} state - Current state
+ * @return {string} device type styles
+ */
+export function getPreviewDeviceStyle( state ) {
+	return state.editor.deviceStyle[ state.editor.deviceType ];
+}


### PR DESCRIPTION
Those are the minimal necessary changes I found to allow us to add custom device types.
I think the 'device type' term isn't the best description for this. 'Preview type' seems more descriptive, IMO, but I didn't want to mess with the already used names.
With these changes, we'd be able to do something like this on our side:

```JavaScript
	setDeviceStyle( 'iframe-popup', {
		width: '400px',
		minHeight: '400px',
		background: 'red',
	} );

	setDeviceType( 'iframe-popup' );
```

Using the term `iframe` in the device type name would indicate that this preview should render inside an iframe.