### PR TITLE
Do not override default window.wp namespace

### DIFF
--- a/src/browser/index.js
+++ b/src/browser/index.js
@@ -109,6 +109,7 @@ function detachEditor( textarea ) {
 
 // This adds the functions to the WP global, making it easier for the example to work.
 window.wp = {
+	...( window.wp ?? {} ),
 	attachEditor,
 	detachEditor,
 };


### PR DESCRIPTION
The code below was overwriting the entire `window.wp` namespace. 

This PR fixes this behaviour so that the new functions are actually added (as intended) without replacing the entire object.