### PR TITLE
Add support to custom previews

### DIFF
--- a/src/components/block-editor/visual-editor.js
+++ b/src/components/block-editor/visual-editor.js
@@ -87,10 +87,11 @@ const VisualEditor = ( { styles } ) => {
 		const { getSettings } = select( blockEditorStore );
 		return getSettings().supportsLayout;
 	}, [] );
-	const { deviceType, deviceStyle } = useSelect( ( select ) => {
+	const { canvasStyles, deviceType, isIframePreview } = useSelect( ( select ) => {
 		return {
+			canvasStyles: select( 'isolated/editor' ).getCanvasStyles(),
 			deviceType: select( 'isolated/editor' ).getPreviewDeviceType(),
-			deviceStyle: select( 'isolated/editor' ).getPreviewDeviceStyle(),
+			isIframePreview: select( 'isolated/editor' ).isIframePreview(),
 		};
 	} );
 	const resizedCanvasStyles = useResizeCanvas( deviceType, false );
@@ -109,10 +110,15 @@ const VisualEditor = ( { styles } ) => {
 		background: 'white',
 	};
 	let animatedStyles = desktopCanvasStyles;
-	if ( deviceStyle ) {
-		animatedStyles = deviceStyle;
-	} else if ( resizedCanvasStyles ) {
+	if ( resizedCanvasStyles ) {
 		animatedStyles = resizedCanvasStyles;
+	}
+
+	if ( canvasStyles ) {
+		animatedStyles = {
+			...animatedStyles,
+			...canvasStyles,
+		};
 	}
 
 	const blockSelectionClearerRef = useBlockSelectionClearer();
@@ -148,9 +154,7 @@ const VisualEditor = ( { styles } ) => {
 			>
 				<motion.div animate={ animatedStyles } initial={ desktopCanvasStyles } className={ previewMode }>
 					<MaybeIframe
-						shouldIframe={
-							deviceType === 'Tablet' || deviceType === 'Mobile' || deviceType.indexOf( 'iframe' ) !== -1
-						}
+						shouldIframe={ isIframePreview }
 						contentRef={ contentRef }
 						styles={ styles }
 						style={ {} }

--- a/src/components/default-settings/index.js
+++ b/src/components/default-settings/index.js
@@ -88,6 +88,8 @@ export default function applyDefaultSettings( settings ) {
 
 			allowApi: iso?.allowApi ?? false,
 
+			disableCanvasAnimations: iso?.disableCanvasAnimations ?? false,
+
 			// No default pattern
 			currentPattern: iso?.currentPattern ?? null,
 

--- a/src/index.js
+++ b/src/index.js
@@ -100,6 +100,7 @@ import './style.scss';
  * @property {Pattern[]} [patterns] - List of patterns
  * @property {Object} [defaultPreferences] - Default preferences if nothing in localStorage
  * @property {boolean} [allowApi] - Allow API requests
+ * @property {boolean} [disableCanvasAnimations] - Disable editor canvas animations
  * @property {SidebarSettings} [sidebar] - Configure sidebar functionality
  */
 

--- a/src/store/editor/actions.js
+++ b/src/store/editor/actions.js
@@ -89,12 +89,12 @@ const actions = {
 	/**
 	 * Set the editor preview mode
 	 *
-	 * @param {boolean} isIFramePreview
+	 * @param {boolean} isIframePreview
 	 */
-	setIsIframePreview( isIFramePreview ) {
+	setIsIframePreview( isIframePreview ) {
 		return {
 			type: 'SET_IFRAME_PREVIEW',
-			isIFramePreview,
+			isIframePreview,
 		};
 	},
 	/**

--- a/src/store/editor/actions.js
+++ b/src/store/editor/actions.js
@@ -76,16 +76,25 @@ const actions = {
 		};
 	},
 	/**
-	 * Set the preview device style
+	 * Set the editor canvas styles
 	 *
-	 * @param {string} deviceType
-	 * @param {string} style
+	 * @param {string} canvasStyles
 	 */
-	setDeviceStyle( deviceType, style ) {
+	setCanvasStyles( canvasStyles ) {
 		return {
-			type: 'SET_DEVICE_STYLE',
-			deviceType,
-			style,
+			type: 'SET_CANVAS_STYLES',
+			canvasStyles,
+		};
+	},
+	/**
+	 * Set the editor preview mode
+	 *
+	 * @param {boolean} isIFramePreview
+	 */
+	setIsIframePreview( isIFramePreview ) {
+		return {
+			type: 'SET_IFRAME_PREVIEW',
+			isIFramePreview,
 		};
 	},
 	/**

--- a/src/store/editor/actions.js
+++ b/src/store/editor/actions.js
@@ -76,6 +76,19 @@ const actions = {
 		};
 	},
 	/**
+	 * Set the preview device style
+	 *
+	 * @param {string} deviceType
+	 * @param {string} style
+	 */
+	setDeviceStyle( deviceType, style ) {
+		return {
+			type: 'SET_DEVICE_STYLE',
+			deviceType,
+			style,
+		};
+	},
+	/**
 	 * Mark this editor as in-use or not
 	 *
 	 * @param {boolean} isEditing

--- a/src/store/editor/reducer.js
+++ b/src/store/editor/reducer.js
@@ -57,7 +57,7 @@ const DEFAULT_STATE = {
 
 	ignoredContent: [],
 	deviceType: 'Desktop',
-	canvasStyles: {},
+	canvasStyles: null,
 	isIframePreview: false,
 
 	settings: {
@@ -93,6 +93,7 @@ const DEFAULT_STATE = {
 		patterns: [],
 		defaultPreferences: {},
 		allowApi: false,
+		disableCanvasAnimations: false,
 	},
 };
 

--- a/src/store/editor/reducer.js
+++ b/src/store/editor/reducer.js
@@ -38,7 +38,8 @@ const getPattern = ( patterns, currentPattern ) =>
  * @property {boolean} isReady - is the editor ready?
  * @property {IsoSettings} settings - editor settings
  * @property {string} deviceType - current device type
- * @property {Object} deviceStyle - preview device style
+ * @property {Object} canvasStyles - editor canvas styles
+ * @property {boolean} isIframePreview - whether the editor canvas is an iframe
  */
 
 /** @type EditorState */
@@ -56,7 +57,8 @@ const DEFAULT_STATE = {
 
 	ignoredContent: [],
 	deviceType: 'Desktop',
-	deviceStyle: {},
+	canvasStyles: {},
+	isIframePreview: false,
 
 	settings: {
 		preferencesKey: null,
@@ -195,13 +197,16 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 				deviceType: action.deviceType,
 			};
 
-		case 'SET_DEVICE_STYLE':
+		case 'SET_CANVAS_STYLES':
 			return {
 				...state,
-				deviceStyle: {
-					...state.deviceStyle,
-					[ action.deviceType ]: action.style,
-				},
+				canvasStyles: action.canvasStyles,
+			};
+
+		case 'SET_IFRAME_PREVIEW':
+			return {
+				...state,
+				isIframePreview: action.isIframePreview,
 			};
 	}
 

--- a/src/store/editor/reducer.js
+++ b/src/store/editor/reducer.js
@@ -38,6 +38,7 @@ const getPattern = ( patterns, currentPattern ) =>
  * @property {boolean} isReady - is the editor ready?
  * @property {IsoSettings} settings - editor settings
  * @property {string} deviceType - current device type
+ * @property {Object} deviceStyle - preview device style
  */
 
 /** @type EditorState */
@@ -55,6 +56,7 @@ const DEFAULT_STATE = {
 
 	ignoredContent: [],
 	deviceType: 'Desktop',
+	deviceStyle: {},
 
 	settings: {
 		preferencesKey: null,
@@ -191,6 +193,15 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 			return {
 				...state,
 				deviceType: action.deviceType,
+			};
+
+		case 'SET_DEVICE_STYLE':
+			return {
+				...state,
+				deviceStyle: {
+					...state.deviceStyle,
+					[ action.deviceType ]: action.style,
+				},
 			};
 	}
 

--- a/src/store/editor/selectors.js
+++ b/src/store/editor/selectors.js
@@ -179,7 +179,7 @@ export function getCanvasStyles( state ) {
  * Whether the editor canvas is an iframe
  *
  * @param {{editor: EditorState}} state - Current state
- * @return {boolean}
+ * @return {boolean} whether the editor canvas is an iframe
  */
 export function isIframePreview( state ) {
 	return state.editor.isIframePreview || [ 'Tablet', 'Mobile' ].includes( state.editor.deviceType );

--- a/src/store/editor/selectors.js
+++ b/src/store/editor/selectors.js
@@ -164,3 +164,13 @@ export function isListViewOpened( state ) {
 export function getPreviewDeviceType( state ) {
 	return state.editor.deviceType;
 }
+
+/**
+ * Return current device type
+ *
+ * @param {{editor: EditorState}} state - Current state
+ * @return {string} device type styles
+ */
+export function getPreviewDeviceStyle( state ) {
+	return state.editor.deviceStyle[ state.editor.deviceType ];
+}

--- a/src/store/editor/selectors.js
+++ b/src/store/editor/selectors.js
@@ -166,11 +166,21 @@ export function getPreviewDeviceType( state ) {
 }
 
 /**
- * Return current device type
+ * Return editor canvas styles
  *
  * @param {{editor: EditorState}} state - Current state
- * @return {string} device type styles
+ * @return {Object} editor canvas styles
  */
-export function getPreviewDeviceStyle( state ) {
-	return state.editor.deviceStyle[ state.editor.deviceType ];
+export function getCanvasStyles( state ) {
+	return state.editor.canvasStyles;
+}
+
+/**
+ * Whether the editor canvas is an iframe
+ *
+ * @param {{editor: EditorState}} state - Current state
+ * @return {boolean}
+ */
+export function isIframePreview( state ) {
+	return state.editor.isIframePreview || [ 'Tablet', 'Mobile' ].includes( state.editor.deviceType );
 }


### PR DESCRIPTION
## Summary

On Crowdsignal, we have been using the Isolated Block Editor as the core of our New Editor Experience (NEX), where the users can build their Surveys (Projects) using blocks.

We offer a few distribution channels to the users to share their Projects with their audience.
Some of these distribution channels should appear on the user's page using specific designs like Popups or Cards.

Currently, the Isolated Block Editor only supports the standard devices: `Desktop`, `Tablet`, and `Mobile`.
We'd like to provide the users a way to preview these distribution channels from inside the Editor.

![image](https://user-images.githubusercontent.com/7811225/191613182-62e611f7-7709-4c9e-b3f1-9e20cd6c2c4f.png)

![image](https://user-images.githubusercontent.com/7811225/191613255-6466a141-3a67-4da3-b719-fb50d245c129.png)

The suggested changes will allow:
* Define whether to show the current preview inside an iframe
* Customize the iframe wrapper styles
* Disable the editor canvas animations


## Testing Instructions

TBD