### PR TITLE
Fix FooterSlot

### DIFF
--- a/src/components/block-editor/text-editor.js
+++ b/src/components/block-editor/text-editor.js
@@ -8,6 +8,7 @@ import React from 'react';
  */
 import PostTextEditor from './post-text-editor';
 import EditorHeading from '../editor-heading-slot';
+import FooterSlot from '../footer-slot';
 
 /**
  * This is a copy of packages/edit-post/src/components/text-editor/index.js
@@ -20,6 +21,7 @@ function TextEditor( {} ) {
 			<div className="edit-post-text-editor__body">
 				<EditorHeading.Slot mode="text" />
 				<PostTextEditor />
+				<FooterSlot.Slot mode="text" />
 			</div>
 		</div>
 	);

--- a/src/components/block-editor/visual-editor.js
+++ b/src/components/block-editor/visual-editor.js
@@ -32,6 +32,7 @@ import { useMergeRefs } from '@wordpress/compose';
  * Internal dependencies
  */
 import EditorHeading from '../editor-heading-slot';
+import FooterSlot from '../footer-slot';
 
 function MaybeIframe( { children, contentRef, shouldIframe, styles, style } ) {
 	const ref = useMouseMoveTypingReset();
@@ -187,6 +188,7 @@ const VisualEditor = ( { styles } ) => {
 						/>
 						<EditorHeading.Slot mode="visual" />
 						<BlockList className={ undefined } __experimentalLayout={ layout } />
+						<FooterSlot.Slot mode="visual" />
 					</MaybeIframe>
 				</PreviewWrapper>
 			</motion.div>


### PR DESCRIPTION
## Summary

Though the [FooterSlot component ](https://github.com/Automattic/isolated-block-editor/blob/trunk/src/components/footer-slot/index.js)exists, it's not being used anywhere, hence it's not working.

This PR adds the `<FooterSlot />` component to the same places where the `<EditorHeading />` is being used.