### PR TITLE
Fix typo in import package namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ If you are not using on a WordPress site then you will need to load the core CSS
 Alternatively you can directly import the bundled `build-browser/core.css` CSS:
 
 ```js
-import '@automatic/isolated-block-editor/build-browser/core.css';
+import '@automattic/isolated-block-editor/build-browser/core.css';
 ```
 
 ## Using
@@ -150,7 +150,7 @@ Include the `IsolatedBlockEditor` module and then create an instance:
 
 ```js
 
-import IsolatedBlockEditor from '@automatic/isolated-block-editor';
+import IsolatedBlockEditor from '@automattic/isolated-block-editor';
 
 render(
 	<IsolatedBlockEditor


### PR DESCRIPTION
This PR updates the example import statements to fix the spelling of the package namespace, which is currently misspelled the namespace as  `@automatic`, instead of `@automattic`, which was throwing an error for "Module is not installed".