### PR TITLE
Add new link button hidden on hover - fixed

### DIFF
--- a/src/components/block-editor-container/style.scss
+++ b/src/components/block-editor-container/style.scss
@@ -100,7 +100,7 @@
 		&:active,
 		&:focus,
 		&:hover {
-			background-color: transparent;
+			background-color: var(--wp-components-color-accent-darker-10,var(--wp-admin-theme-color-darker-10,#006BA1));
 			background-image: none;
 		}
 	}


### PR DESCRIPTION
Trac ticket: [#6991](https://meta.trac.wordpress.org/ticket/6991)

### Issue
When creating a link, the apply button is hidden on hover.

### Solution
Applying the background variable value can solve the issue. Code is added.