### PR TITLE
WordPress `6.4` Support

### DIFF
--- a/src/components/block-editor/visual-editor.js
+++ b/src/components/block-editor/visual-editor.js
@@ -13,7 +13,6 @@ import {
 	store as blockEditorStore,
 	__unstableUseBlockSelectionClearer as useBlockSelectionClearer,
 	__unstableUseTypewriter as useTypewriter,
-	__unstableUseClipboardHandler as useClipboardHandler,
 	__unstableUseTypingObserver as useTypingObserver,
 	__experimentalUseResizeCanvas as useResizeCanvas,
 	__unstableEditorStyles as EditorStyles,
@@ -176,13 +175,7 @@ export default function VisualEditor( { styles } ) {
 	}
 
 	const ref = useRef();
-	const contentRef = useMergeRefs( [
-		ref,
-		useClipboardHandler(),
-		useTypewriter(),
-		useTypingObserver(),
-		useBlockSelectionClearer(),
-	] );
+	const contentRef = useMergeRefs( [ ref, useTypewriter(), useTypingObserver(), useBlockSelectionClearer() ] );
 
 	const blockSelectionClearerRef = useBlockSelectionClearer();
 

--- a/src/components/block-editor/visual-editor.js
+++ b/src/components/block-editor/visual-editor.js
@@ -39,15 +39,12 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 import EditorHeading from '../editor-heading-slot';
 import FooterSlot from '../footer-slot';
 
-export const { lock, unlock } =
-	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.',
-		'@wordpress/edit-post'
-	);
-
-const { LayoutStyle, useLayoutClasses, useLayoutStyles } = unlock(
-	blockEditorPrivateApis
+export const { lock, unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+	'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
+	'@wordpress/edit-post'
 );
+
+const { LayoutStyle, useLayoutClasses, useLayoutStyles } = unlock( blockEditorPrivateApis );
 
 function MaybeIframe( { children, contentRef, shouldIframe, styles, style } ) {
 	const ref = useMouseMoveTypingReset();


### PR DESCRIPTION
These are the only changes I found necessary to support the latest Gutenberg plugin which will be going in to WordPress `6.4`.

Note: This will break usage below WordPress `6.4.`