### PR TITLE
Remove stray double quote from usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ import '@automattic/isolated-block-editor/build-browser/core.css';
 
 The module is currently only available on Github and can be added with:
 
-`npm install @automattic/isolated-block-editor@1.2.0" --save` (where `1.2.0` is the version you want to use)
+`npm install @automattic/isolated-block-editor@1.2.0 --save` (where `1.2.0` is the version you want to use)
 
 ## Future
 


### PR DESCRIPTION
This PR removes an accidental double quote in the usage instructions.