### PR TITLE
Add editor_gutenberg Moodle plugin skeleton

### DIFF
--- a/lib/editor/gutenberg/amd/src/editor.js
+++ b/lib/editor/gutenberg/amd/src/editor.js
@@ -1,0 +1,44 @@
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Gutenberg editor AMD module.
+ *
+ * @module     editor_gutenberg/editor
+ * @copyright  2026 Aldrin Magno
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+define([], function() {
+    'use strict';
+
+    return {
+        /**
+         * Initialise the Gutenberg editor for a given textarea.
+         *
+         * @param {Object} config Configuration object.
+         * @param {string} config.elementId The ID of the textarea to replace.
+         * @param {Object} config.options Editor options from Moodle.
+         * @param {Object} config.fpoptions File picker options.
+         */
+        init: function(config) {
+            var textarea = document.getElementById(config.elementId);
+            if (!textarea) {
+                return;
+            }
+            // Placeholder: Gutenberg block editor will be mounted here.
+        }
+    };
+});

--- a/lib/editor/gutenberg/classes/editor.php
+++ b/lib/editor/gutenberg/classes/editor.php
@@ -1,0 +1,99 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Gutenberg editor integration.
+ *
+ * @package    editor_gutenberg
+ * @copyright  2026 Aldrin Magno
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace editor_gutenberg;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Gutenberg editor class.
+ *
+ * Integrates the Automattic Isolated Block Editor (Gutenberg)
+ * as a text editor within Moodle.
+ *
+ * @package    editor_gutenberg
+ * @copyright  2026 Aldrin Magno
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class editor extends \texteditor {
+
+    /**
+     * Is the current browser supported by this editor?
+     *
+     * @return bool
+     */
+    public function supported_by_browser(): bool {
+        return true;
+    }
+
+    /**
+     * Returns array of supported text formats.
+     *
+     * @return array
+     */
+    public function get_supported_formats(): array {
+        return [FORMAT_HTML => FORMAT_HTML];
+    }
+
+    /**
+     * Returns the preferred text format.
+     *
+     * @return int
+     */
+    public function get_preferred_format(): int {
+        return FORMAT_HTML;
+    }
+
+    /**
+     * Does this editor support picking from repositories?
+     *
+     * @return bool
+     */
+    public function supports_repositories(): bool {
+        return true;
+    }
+
+    /**
+     * Add required JS and CSS for the editor to the page.
+     *
+     * @param string $elementid The ID of the textarea element.
+     * @param array|null $options Editor options.
+     * @param array|null $fpoptions File picker options.
+     */
+    public function use_editor($elementid, array $options = null, $fpoptions = null) {
+        global $PAGE;
+
+        $jsoptions = json_encode([
+            'elementId' => $elementid,
+            'options' => $options,
+            'fpoptions' => $fpoptions,
+        ]);
+
+        $PAGE->requires->js_amd_inline("
+            require(['editor_gutenberg/editor'], function(GutenbergEditor) {
+                GutenbergEditor.init({$jsoptions});
+            });
+        ");
+    }
+}

--- a/lib/editor/gutenberg/db/access.php
+++ b/lib/editor/gutenberg/db/access.php
@@ -1,0 +1,27 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Gutenberg editor capabilities.
+ *
+ * @package    editor_gutenberg
+ * @copyright  2026 Aldrin Magno
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$capabilities = [];

--- a/lib/editor/gutenberg/lang/en/editor_gutenberg.php
+++ b/lib/editor/gutenberg/lang/en/editor_gutenberg.php
@@ -1,0 +1,28 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Strings for component 'editor_gutenberg', language 'en'.
+ *
+ * @package    editor_gutenberg
+ * @copyright  2026 Aldrin Magno
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$string['pluginname'] = 'Gutenberg';
+$string['privacy:metadata'] = 'The Gutenberg editor plugin does not store any personal data.';

--- a/lib/editor/gutenberg/lib.php
+++ b/lib/editor/gutenberg/lib.php
@@ -1,0 +1,27 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Gutenberg editor library.
+ *
+ * @package    editor_gutenberg
+ * @copyright  2026 Aldrin Magno
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+class_alias(\editor_gutenberg\editor::class, 'gutenberg_texteditor');

--- a/lib/editor/gutenberg/settings.php
+++ b/lib/editor/gutenberg/settings.php
@@ -1,0 +1,25 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Gutenberg editor settings.
+ *
+ * @package    editor_gutenberg
+ * @copyright  2026 Aldrin Magno
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();

--- a/lib/editor/gutenberg/version.php
+++ b/lib/editor/gutenberg/version.php
@@ -1,0 +1,31 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Gutenberg editor version information.
+ *
+ * @package    editor_gutenberg
+ * @copyright  2026 Aldrin Magno
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$plugin->component = 'editor_gutenberg';
+$plugin->version   = 2026032700;
+$plugin->requires  = 2024042200;
+$plugin->maturity  = MATURITY_ALPHA;
+$plugin->release   = '0.1.0';


### PR DESCRIPTION
Scaffold the complete Moodle editor plugin boilerplate for editor_gutenberg, which will integrate Automattic's Isolated Block Editor (Gutenberg) into Moodle as a selectable text editor.

Files follow the editor_tiny/editor_atto patterns:
- classes/editor.php: Main editor class extending \texteditor with all 5 abstract methods implemented (supported_by_browser, get_supported_formats, get_preferred_format, supports_repositories, use_editor)
- lib.php: Class alias for backward compatibility
- version.php: Plugin metadata targeting Moodle 4.4+
- lang/en/editor_gutenberg.php: Required language strings
- amd/src/editor.js: AMD module stub for JS initialization
- settings.php and db/access.php: Empty placeholders

The plugin installs cleanly and appears in Site admin > Plugins > Text editors but does not yet implement the actual Gutenberg editor integration.

https://claude.ai/code/session_01UP26gceb9yc8Z3SVX2ip6x